### PR TITLE
add logging to hot-reload.md for mobile hot reload

### DIFF
--- a/main.js
+++ b/main.js
@@ -70,6 +70,11 @@ module.exports = class HotReload extends Plugin {
             await plugins.enablePlugin(plugin);
             console.debug("enabled", plugin);
             new Notice(`Plugin "${plugin}" has been reloaded`);
+            const tFile = this.app.vault.getAbstractFileByPath('hot-reload.md')
+            if (tFile) {
+            const content = await this.app.vault.read(tFile)
+            await this.app.vault.modify(tFile, plugin.concat("\n", content))
+            }
         } catch(e) {}
     }
 


### PR DESCRIPTION
This is a change to support the [Hot Reload Mobile plugin](https://github.com/shabegom/obsidian-hot-reload-mobile) I've developed. Hot Reload mobile looks for changes to a `hot-reload.md` file in the mobile vault. When it sees a change in that file, it reloads the specified plugin.

This code change is to log the latest plugin reloaded on the Desktop to `hot-reload.md`. It looks for the TFile and if that file exists in the vault it writes the plugin id to it.

Maybe there are better ways to do this? probably, but this seems to work.