### PR TITLE
fix unexisting path after plugin uninstallation

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,6 +34,9 @@ module.exports = class HotReload extends Plugin {
     watch(path) {
         if (this.app.vault.adapter.watchers.hasOwnProperty(path)) return;
         const realPath = [this.app.vault.adapter.basePath, path].join("/");
+        if (!fs.existsSync(realPath)) {
+            return;
+        }
         const lstat = fs.lstatSync(realPath);
         if (lstat && (watchNeeded || lstat.isSymbolicLink()) && fs.statSync(realPath).isDirectory()) {
             this.app.vault.adapter.startWatchPath(path, false);
@@ -45,6 +48,9 @@ module.exports = class HotReload extends Plugin {
         for (const dir of Object.keys(this.pluginNames)) {
             for (const file of ["manifest.json", "main.js", "styles.css", ".hotreload"]) {
                 const path = `${base}/${dir}/${file}`;
+                if (!fs.existsSync(path)) {
+                    return;
+                }
                 const stat = await app.vault.adapter.stat(path);
                 if (stat) {
                     if (this.statCache.has(path) && stat.mtime !== this.statCache.get(path).mtime) {

--- a/main.js
+++ b/main.js
@@ -48,7 +48,6 @@ module.exports = class HotReload extends Plugin {
         for (const dir of Object.keys(this.pluginNames)) {
             for (const file of ["manifest.json", "main.js", "styles.css", ".hotreload"]) {
                 const path = `${base}/${dir}/${file}`;
-                if (!fs.existsSync(path)) continue;
                 const stat = await app.vault.adapter.stat(path);
                 if (stat) {
                     if (this.statCache.has(path) && stat.mtime !== this.statCache.get(path).mtime) {


### PR DESCRIPTION
fixing this error when uninstalling any plugin

app.js:1 Uncaught Error: ENOENT: no such file or directory, lstat 'C:\Users\dd200\Documents\Dev Plugins/.obsidian/plugins/obsidian-projects'
    at lstatSync (node:fs:1593:3)
    at t.lstatSync (node:electron/js2c/asar_bundle:2:3776)
    at HotReload.watch (plugin:hot-reload:30:26)
    at HotReload.onFileChange (plugin:hot-reload:70:65)
    at e.tryTrigger (app.js:1:725395)
    at e.trigger (app.js:1:725328)
    at t.trigger (app.js:1:743459)
    at t.onChange (app.js:1:734117)
    at e.trigger (app.js:1:552829)