### PR TITLE
Rebuild active editor on reload

### DIFF
--- a/main.js
+++ b/main.js
@@ -100,6 +100,8 @@ module.exports = class HotReload extends Plugin {
         localStorage.setItem("debug-plugin", "1");
         try {
             await plugins.enablePlugin(plugin);
+            // Ensure rendering-related changes are displayed automatically
+		    app.workspace.activeEditor.leaf.rebuildView();
         } finally {
             // Restore previous setting
             if (oldDebug === null) localStorage.removeItem("debug-plugin"); else localStorage.setItem("debug-plugin", oldDebug);

--- a/main.js
+++ b/main.js
@@ -101,7 +101,7 @@ module.exports = class HotReload extends Plugin {
         try {
             await plugins.enablePlugin(plugin);
             // Ensure rendering-related changes are displayed automatically
-		    app.workspace.activeEditor.leaf.rebuildView();
+	    app.workspace.activeEditor.leaf.rebuildView();
         } finally {
             // Restore previous setting
             if (oldDebug === null) localStorage.removeItem("debug-plugin"); else localStorage.setItem("debug-plugin", oldDebug);


### PR DESCRIPTION
In developing a plugin that uses code block processors, I noticed that the active editor will not re-render changes I made relating to what's being rendered in the code block. 

Rebuilding the active editor seems to be the fix for this.